### PR TITLE
Fix transparency toggle bug in fade routine

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -3591,7 +3591,12 @@ function Library:CreateWindow(...)
                     continue;
                 end;
 
-                TweenService:Create(Desc, TweenInfo.new(FadeTime, Enum.EasingStyle.Linear), { [Prop] = Toggled and Cache[Prop] or 1 }):Play();
+                local Target = 1;
+                if Toggled then
+                    Target = Cache[Prop];
+                end;
+
+                TweenService:Create(Desc, TweenInfo.new(FadeTime, Enum.EasingStyle.Linear), { [Prop] = Target }):Play();
             end;
         end;
 


### PR DESCRIPTION
## Summary
- avoid incorrect fallback when toggling faded UI elements

## Testing
- `luac -p gui.lua` *(fails: command not found)*
- `lua -v` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a34038634c8329b64d34d5e2b5d64d